### PR TITLE
Abort ewake if no interface has been found

### DIFF
--- a/src/helper/ParsedArgs.ts
+++ b/src/helper/ParsedArgs.ts
@@ -129,6 +129,11 @@ function handleArgs(): Opts {
         processedOpts.NETWORK_INTERFACE = networkInterface;
     }
 
+    if (!processedOpts.NETWORK_INTERFACE) {
+        console.warn("Could not find any network interface");
+        process.exit(1);
+    }
+
     if (!processedOpts.CLIENT_JSON && !processedOpts.HTTP_GET) {
         console.warn("you have to specify one option for receiving clients.json (option file or option http)");
         showHelp();


### PR DESCRIPTION
This will make ewake fail immediately and doesn't leave it running when no suitable interface has been found.
This prevents ewake from being online but not working correctly